### PR TITLE
Fixed support for Windows, added support for WSL, and other UX changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,13 @@
           "scope": "resource",
           "type": "string",
           "default": "",
-          "markdownDescription": "Manually set a futhark executable, the path must ends `futhark` (e,g, `~/.local/bin/futhark`), supports `~` and `${HOME}`. Reload Window after change to take effect."
+          "markdownDescription": "Path to a Futhark executable. Supports `~` and `${HOME}`. Reload window after modifying."
+        },
+        "futhark.useWSL": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": "false",
+          "markdownDescription": "When using Windows, run Futhark within Windows Subsystem for Linux (WSL)."
         }
       }
     },
@@ -86,7 +92,6 @@
   },
   "dependencies": {
     "@types/semver": "^7.3.9",
-    "@types/which": "^2.0.1",
     "vscode-languageclient": "^7.0.0",
     "which": "^2.0.2"
   }


### PR DESCRIPTION
## Summary 

In Windows, the `which` package appends ".EXE" to the path. Because file validation was performed using `.endsWith(langName)`, this caused the extension to fail on Windows machines. Additionally, since the focus was on file paths, a user would not be able to configure `futhark-vscode` to use WSL. I refactored the extension to remove the filename validation, which also allowed me to add WSL support. My assumption is that the Futhark version check is sufficient enough validation. 

I also modified some of the messages and added options to the error windows, but you're free to remove these changes. My main goal is the fix for Windows and WSL support.

## Changes

- Changed Futhark version check to use regex capture groups.

- Removed filename validation.

- Removed dependency for `which`.

- Added WSL options to version check and language client.

- Added "Use WSL" extension setting.

- Renamed `findFutharkExecutable` to `validateFutharkPath`.

- `validateFutharkPath` changed to return a `ServerOptions` object.

- Added options to error message windows.

- Changed wording of error messages and `futharkExecutablePath` description.